### PR TITLE
Remove previous feedback and grade on submit

### DIFF
--- a/classes/listener/observer.php
+++ b/classes/listener/observer.php
@@ -127,6 +127,16 @@ class observer {
             'archive' => base64_encode($submitedfile->get_content()),
         );
 
+        // Remove previous feedback for the assignament
+        $teachercommenttext = "Waiting for automatic feedback";
+    
+        $data = new \stdClass();
+        $data->attemptnumber = -1;
+        $data->grade = -1;
+        $data->assignfeedbackcomments_editor = ['text' => $teachercommenttext, 'format' => FORMAT_MOODLE];
+        
+        $assign->save_grade($submission->userid, $data);
+
         $api = new \block_vmchecker\backend\api(get_config('block_vmchecker', 'backend'));
         $response = $api->submit($payload);
         if (empty($response)) {


### PR DESCRIPTION
This PR implements the changes proposed in #14 by removing any outdated grade/feedback when the submission is updated. Also, placed a temporary feedback indicating that a VMchecker-based one will be available soon.